### PR TITLE
Travis CI: Lint for Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: python
 install: pip install flake8
-script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+script: flake8 . --count --select=E9,F63,F72,F82 --max-line-length=127 --show-source --statistics

--- a/text2bin.py
+++ b/text2bin.py
@@ -40,6 +40,8 @@ have the same number of columns (i.e., be the same dimension).
 
 """
 
+from __future__ import print_function
+
 from itertools import izip
 from getopt import GetoptError, getopt
 import os
@@ -50,7 +52,7 @@ try:
   opts, args = getopt(
       sys.argv[1:], 'o:v:', ['output=', 'vocab='])
 except GetoptError as e:
-  print >> sys.stderr, e
+  print(e, file=sys.stderr)
   sys.exit(2)
 
 opt_output = 'vecs.bin'
@@ -74,7 +76,7 @@ def go(fhs):
           # raise IOError('vector files must be aligned')
           continue
 
-        print >> vocab_out, token
+        print(token, file=vocab_out)
 
         vec = [sum(float(x) for x in xs) for xs in zip(*parts)[1:]]
         if not fmt:


### PR DESCRIPTION
Automates the discovery of #9 and other problems.

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3. 